### PR TITLE
Add support for improved bind parameter declarations

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/data-types.adoc
+++ b/r2dbc-spec/src/main/asciidoc/data-types.adoc
@@ -10,8 +10,8 @@ If a data source does not support a data type described in this chapter, a drive
 [[datatypes.mapping]]
 == Mapping of Data Types
 
-This section explains how SQL-specific types are mapped to Java types.
-The list is not exhaustive and should be received as a guideline for drivers.
+This section explains how SQL-specific types map to Java types.
+The list is not exhaustive and should be received as a guideline for drivers. 
 R2DBC drivers should use modern types and type descriptors to exchange data for consumption by applications and consumption by the driver.
 Driver implementations should implement the following type mapping and can support additional type mappings:
 
@@ -174,6 +174,11 @@ The following table describes the SQL type mapping for collection types:
 |===
 
 Vendor-specific types (such as spatial data types, structured JSON or XML data, and user-defined types) are subject to vendor-specific mapping.
+
+[[datatypes.descriptor]]
+== Type Descriptors
+
+R2DBC drivers may infer the database type for inbound parameters or use a specific type. R2DBC's type system `io.r2dbc.spi.Type` and `io.r2dbc.spi.Parameter` are interfaces to describe a database type and a typed parameter. The R2DBC specification defines its type mapping in the `io.r2dbc.spi.R2dbcTypes` utility for commonly used data types. R2DBC drivers may provide their own `Type` objects to provide vendor-specific type support.
 
 [[datatypes.mapping.advanced]]
 == Mapping of Advanced Data Types

--- a/r2dbc-spec/src/main/asciidoc/statements.adoc
+++ b/r2dbc-spec/src/main/asciidoc/statements.adoc
@@ -73,7 +73,7 @@ Parameterized statements may be cached by R2DBC implementations for reuse (for e
 === Binding Parameters
 
 The `Statement` interface defines `bind(…)` and `bindNull(…)` methods to provide parameter values for bind marker substitution.
-The parameter type is defined by the actual value that is bound to a parameter.
+A parameter value consists of the actual value that is bound to a parameter and its type. Using scalar values according to <<datatypes.mapping>> lets the R2DBC infer the actual database type. Using a `Parameter` object allows for more control over the database type definition.
 Each bind method accepts two arguments.
 The first is either an ordinal position parameter starting at `0` (zero) or the parameter placeholder representation.
 The method of parameter binding (positional or by identifier) is vendor-specific, and a driver should document its preferred binding mechanism.
@@ -101,6 +101,19 @@ Alternatively, parameters can be bound by index, as the following example shows:
 Statement statement = connection.createStatement("SELECT title FROM books WHERE author = $1 and publisher = $2");
 statement.bind(0, "John Doe");
 statement.bind(1, "Happy Books LLC");
+----
+====
+
+Binding parameters using a `Parameter` with a `Type` allows for more control over the actual database type. `io.r2dbc.spi.R2dbcTypes` defines commonly used types.
+
+.Binding parameters to a `Statement` object using a `Parameter` object
+====
+[source,java]
+----
+// connection is a Connection object
+Statement statement = connection.createStatement("SELECT title FROM books WHERE author = $1 and publisher = $2");
+statement.bind(0, Parameters.in(R2dbcTypes.NVARCHAR, "John Doe"));
+statement.bind(1, Parameters.in(R2dbcTypes.VARCHAR, "Happy Books LLC"));
 ----
 ====
 
@@ -140,7 +153,7 @@ It takes two parameters:
 
 The following example shows how to set `NULL` value:
 
-.Setting a `NULL` value.
+.Setting a `NULL` value using type inference.
 ====
 [source,java]
 ----
@@ -148,6 +161,19 @@ The following example shows how to set `NULL` value:
 statement.bindNull(0, String.class);
 ----
 ====
+
+Typed `Parameter` objects representing a null value can be bound either by calling `bindNull(…)` or `bind(…)`:
+
+.Setting a typed `NULL` value.
+====
+[source,java]
+----
+// statement is a Statement object
+statement.bind(0, Parameters.in(R2dbcTypes.VARCHAR));
+----
+====
+
+NOTE: Not all databases allow for a non-typed `NULL` to be sent to the underlying database.
 
 [[statements.generated-values]]
 == Retrieving Auto Generated Values

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockColumnMetadata.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockColumnMetadata.java
@@ -18,10 +18,13 @@ package io.r2dbc.spi.test;
 
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Nullability;
+import io.r2dbc.spi.Type;
 
 public final class MockColumnMetadata implements ColumnMetadata {
 
     private final Class<?> javaType;
+
+    private final Type type;
 
     private final String name;
 
@@ -33,8 +36,10 @@ public final class MockColumnMetadata implements ColumnMetadata {
 
     private final Integer scale;
 
-    private MockColumnMetadata(@Nullable Class<?> javaType, String name, @Nullable Object nativeTypeMetadata, Nullability nullability, @Nullable Integer precision, @Nullable Integer scale) {
+    private MockColumnMetadata(@Nullable Class<?> javaType, Type type, String name, @Nullable Object nativeTypeMetadata, Nullability nullability, @Nullable Integer precision,
+                               @Nullable Integer scale) {
         this.javaType = javaType;
+        this.type = Assert.requireNonNull(type, "type must not be null");
         this.name = Assert.requireNonNull(name, "name must not be null");
         this.nativeTypeMetadata = nativeTypeMetadata;
         this.nullability = Assert.requireNonNull(nullability, "nullability must not be null");
@@ -56,6 +61,11 @@ public final class MockColumnMetadata implements ColumnMetadata {
     @Override
     public Class<?> getJavaType() {
         return this.javaType;
+    }
+
+    @Override
+    public Type getType() {
+        return this.type;
     }
 
     @Override
@@ -87,6 +97,7 @@ public final class MockColumnMetadata implements ColumnMetadata {
     public String toString() {
         return "MockColumnMetadata{" +
             "javaType=" + this.javaType +
+            "type=" + this.type +
             ", name='" + this.name + '\'' +
             ", nativeTypeMetadata=" + this.nativeTypeMetadata +
             ", nullability=" + this.nullability +
@@ -98,6 +109,8 @@ public final class MockColumnMetadata implements ColumnMetadata {
     public static final class Builder {
 
         private Class<?> javaType;
+
+        private Type type;
 
         private String name;
 
@@ -113,11 +126,30 @@ public final class MockColumnMetadata implements ColumnMetadata {
         }
 
         public MockColumnMetadata build() {
-            return new MockColumnMetadata(this.javaType, this.name, this.nativeTypeMetadata, this.nullability, this.precision, this.scale);
+            return new MockColumnMetadata(this.javaType, this.type, this.name, this.nativeTypeMetadata, this.nullability, this.precision, this.scale);
         }
 
         public Builder javaType(Class<?> type) {
             this.javaType = Assert.requireNonNull(type, "javaType must not be null");
+            if (this.type == null) {
+                this.type = new Type.InferredType() {
+
+                    @Override
+                    public Class<?> getJavaType() {
+                        return type;
+                    }
+
+                    @Override
+                    public String getName() {
+                        return type.getSimpleName();
+                    }
+                };
+            }
+            return this;
+        }
+
+        public Builder type(Type type) {
+            this.type = Assert.requireNonNull(type, "type must not be null");
             return this;
         }
 

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockType.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockType.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi.test;
+
+import io.r2dbc.spi.Type;
+
+public final class MockType implements Type {
+
+    private final Class<?> javaType;
+
+    private final String name;
+
+    public MockType(Class<?> javaType, String name) {
+        this.javaType = javaType;
+        this.name = name;
+    }
+
+    @Override
+    public Class<?> getJavaType() {
+        return this.javaType;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String toString() {
+        return "MockType{" +
+            "javaType=" + this.javaType +
+            ", name='" + this.name + '\'' +
+            '}';
+    }
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ColumnMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ColumnMetadata.java
@@ -39,6 +39,14 @@ public interface ColumnMetadata {
     }
 
     /**
+     * Returns the database {@link Type}.
+     *
+     * @return the database {@link Type} descriptor.
+     * @since 0.9
+     */
+    Type getType();
+
+    /**
      * Returns the name of the column.
      * <p>
      * The name does not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result..

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Parameter.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Parameter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Represents a parameter to be interchanged. Parameters are typed and can define a value. Parameters without a value correspond with a SQL {@code NULL} value.
+ * <p>
+ * Parameters can be classified as {@link In input} or {@link Out output} parameters.
+ *
+ * @since 0.9
+ */
+public interface Parameter {
+
+    /**
+     * Returns the parameter.
+     *
+     * @return the type to be sent to the database.
+     */
+    Type getType();
+
+    /**
+     * Returns the value.
+     *
+     * @return the value for this parameter.  Value can be {@code null}.
+     */
+    @Nullable
+    Object getValue();
+
+    /**
+     * Marker interface to classify a parameter as input parameter. Parameters that do not implement {@link Out} default to in parameters.
+     */
+    interface In {
+
+    }
+
+    /**
+     * Marker interface to classify a parameter as output parameter. Parameters can implement both, {@code In} and {@code Out} interfaces to be classified as in-out parameters.
+     */
+    interface Out {
+
+    }
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Parameters.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Parameters.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Utility to create {@link Parameter} objects.
+ *
+ * @since 0.9
+ */
+public final class Parameters {
+
+    private Parameters() {
+    }
+
+    /**
+     * Create a {@code NULL IN} parameter using the given {@link Type}.
+     *
+     * @param type the type to be sent to the database.
+     * @return the in parameter.
+     * @throws IllegalArgumentException if {@code type} is {@code null}.
+     */
+    public static Parameter in(Type type) {
+        Assert.requireNonNull(type, "Type must not be null");
+        return in(type, null);
+    }
+
+    /**
+     * Create a {@code NULL IN} parameter using type inference and the given {@link Class type} hint.  The actual {@link Type} is inferred during statement execution.
+     *
+     * @param type the type to be used for type inference.
+     * @return the in parameter.
+     * @throws IllegalArgumentException if {@code type} is {@code null}.
+     */
+    public static Parameter in(Class<?> type) {
+        Assert.requireNonNull(type, "Type must not be null");
+        return in(new DefaultInferredType(type), null);
+    }
+
+    /**
+     * Create a {@code IN} parameter using the given {@code value}.  The actual {@link Type} is inferred during statement execution.
+     *
+     * @param value the value to be used for type inference.
+     * @return the in parameter.
+     * @throws IllegalArgumentException if {@code value} is {@code null}.
+     */
+    public static Parameter in(Object value) {
+        Assert.requireNonNull(value, "Value must not be null");
+        return in(new DefaultInferredType(value.getClass()), value);
+    }
+
+    /**
+     * Create a {@code IN} parameter using the given {@link Type} and {@code value}.
+     *
+     * @param type  the type to be sent to the database.
+     * @param value the value associated with the parameter, can be {@code null}.
+     * @return the in parameter.
+     * @throws IllegalArgumentException if {@code type} is {@code null}.
+     */
+    public static Parameter in(Type type, @Nullable Object value) {
+        Assert.requireNonNull(type, "Type must not be null");
+        return new InParameter(type, value);
+    }
+
+    /**
+     * Create a {@code NULL OUT} parameter using the given {@link Type}.
+     *
+     * @param type the type to be sent to the database.
+     * @return the out parameter.
+     * @throws IllegalArgumentException if {@code type} is {@code null}.
+     */
+    public static Parameter out(Type type) {
+        Assert.requireNonNull(type, "Type must not be null");
+        return in(type, null);
+    }
+
+    /**
+     * Create a {@code NULL OUT} parameter using type inference and the given {@link Class type} hint.  The actual {@link Type} is inferred during statement execution.
+     *
+     * @param type the type to be used for type inference.
+     * @return the out parameter.
+     * @throws IllegalArgumentException if {@code type} is {@code null}.
+     */
+    public static Parameter out(Class<?> type) {
+        Assert.requireNonNull(type, "Type must not be null");
+        return in(new DefaultInferredType(type), null);
+    }
+
+    /**
+     * Create a {@code OUT} parameter using the given {@code value}.  The actual {@link Type} is inferred during statement execution.^
+     *
+     * @param value the value to be used for type inference.
+     * @return the out parameter.
+     * @throws IllegalArgumentException if {@code value} is {@code null}.
+     */
+    public static Parameter out(Object value) {
+        Assert.requireNonNull(value, "Value must not be null");
+        return in(new DefaultInferredType(value.getClass()), value);
+    }
+
+    /**
+     * Create a {@code OUT} parameter using the given {@link Type} and {@code value}.
+     *
+     * @param type  the type to be sent to the database.
+     * @param value the value associated with the parameter, can be {@code null}.
+     * @return the out parameter.
+     * @throws IllegalArgumentException if {@code type} is {@code null}.
+     */
+    public static Parameter out(Type type, @Nullable Object value) {
+        Assert.requireNonNull(type, "Type must not be null");
+        return new OutParameter(type, value);
+    }
+
+    private static class DefaultParameter implements Parameter {
+
+        private final Type type;
+
+        @Nullable
+        private final Object value;
+
+        public DefaultParameter(Type type, @Nullable Object value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        @Override
+        public Type getType() {
+            return this.type;
+        }
+
+        @Override
+        public Object getValue() {
+            return this.value;
+        }
+    }
+
+    private static class InParameter extends DefaultParameter implements Parameter.In {
+
+        public InParameter(Type type, @Nullable Object value) {
+            super(type, value);
+        }
+
+        @Override
+        public String toString() {
+            return "In{" +
+                getType() +
+                '}';
+        }
+    }
+
+    private static class OutParameter extends DefaultParameter implements Parameter.Out {
+
+        public OutParameter(Type type, @Nullable Object value) {
+            super(type, value);
+        }
+
+        @Override
+        public String toString() {
+            return "Out{" +
+                getType() +
+                '}';
+        }
+    }
+
+    private static class DefaultInferredType implements Type.InferredType, Type {
+
+        private final Class<?> javaType;
+
+        DefaultInferredType(Class<?> javaType) {
+            this.javaType = javaType;
+        }
+
+        @Override
+        public Class<?> getJavaType() {
+            return this.javaType;
+        }
+
+        @Override
+        public String getName() {
+            return "(inferred)";
+        }
+
+        @Override
+        public String toString() {
+            return "Inferred: " + getJavaType().getName();
+        }
+    }
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTypes.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTypes.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+
+/**
+ * Definition of generic SQL types.
+ *
+ * @since 0.9
+ */
+public enum R2dbcTypes implements Type {
+
+    // ----------------------------------------------------
+    // Character types
+    // ----------------------------------------------------
+
+    /**
+     * Identifies the generic SQL type {@code CHAR}.
+     */
+    CHAR(String.class),
+
+    /**
+     * Identifies the generic SQL type {@code VARCHAR}.
+     */
+    VARCHAR(String.class),
+
+    /**
+     * Identifies the generic SQL type {@code NCHAR}.
+     */
+    NCHAR(String.class),
+
+    /**
+     * Identifies the generic SQL type {@code NVARCHAR}.
+     */
+    NVARCHAR(String.class),
+
+    /**
+     * Identifies the generic SQL type {@code CLOB}.
+     */
+    CLOB(ByteBuffer.class),
+
+    /**
+     * Identifies the generic SQL type {@code NCLOB}.
+     */
+    NCLOB(ByteBuffer.class),
+
+    // ----------------------------------------------------
+    // Boolean types
+    // ----------------------------------------------------
+
+    /**
+     * Identifies the generic SQL type {@code BOOLEAN}.
+     */
+    BOOLEAN(Boolean.class),
+
+    // ----------------------------------------------------
+    // Binary types
+    // ----------------------------------------------------
+
+    /**
+     * Identifies the generic SQL type {@code BINARY}.
+     */
+    BINARY(ByteBuffer.class),
+
+    /**
+     * Identifies the generic SQL type {@code VARBINARY}.
+     */
+    VARBINARY(ByteBuffer.class),
+
+    /**
+     * Identifies the generic SQL type {@code BLOB}.
+     */
+    BLOB(ByteBuffer.class),
+
+    // ----------------------------------------------------
+    // Numeric types
+    // ----------------------------------------------------
+
+    /**
+     * Identifies the generic SQL type {@code INTEGER}.
+     */
+    INTEGER(Integer.class),
+
+    /**
+     * Identifies the generic SQL type {@code TINYINT}.
+     */
+    TINYINT(Byte.class),
+
+    /**
+     * Identifies the generic SQL type {@code SMALLINT}.
+     */
+    SMALLINT(Short.class),
+
+    /**
+     * Identifies the generic SQL type {@code BIGINT}.
+     */
+    BIGINT(Long.class),
+
+    /**
+     * Identifies the generic SQL type {@code NUMERIC}.
+     */
+    NUMERIC(BigDecimal.class),
+
+    /**
+     * Identifies the generic SQL type {@code DECIMAL}.
+     */
+    DECIMAL(BigDecimal.class),
+
+    /**
+     * Identifies the generic SQL type {@code FLOAT}.
+     */
+    FLOAT(Double.class),
+
+    /**
+     * Identifies the generic SQL type {@code REAL}.
+     */
+    REAL(Float.class),
+
+    /**
+     * Identifies the generic SQL type {@code DOUBLE}.
+     */
+    DOUBLE(Double.class),
+
+    // ----------------------------------------------------
+    // Date/Time types
+    // ----------------------------------------------------
+
+    /**
+     * Identifies the generic SQL type {@code DATE}.
+     */
+    DATE(LocalDate.class),
+
+    /**
+     * Identifies the generic SQL type {@code TIME}.
+     */
+    TIME(LocalTime.class),
+
+    /**
+     * Identifies the generic SQL type {@code TIME WITH TIME ZONE}.
+     */
+    TIME_WITH_TIME_ZONE(OffsetTime.class),
+
+    /**
+     * Identifies the generic SQL type {@code TIMESTAMP}.
+     */
+    TIMESTAMP(LocalDateTime.class),
+
+    /**
+     * Identifies the generic SQL type {@code TIMESTAMP WITH TIME ZONE}.
+     */
+    TIMESTAMP_WITH_TIME_ZONE(LocalDateTime.class),
+
+    /**
+     * Identifies the generic SQL type {@code ARRAY}.
+     */
+    COLLECTION(Object[].class);
+
+    private final Class<?> javaType;
+
+    R2dbcTypes(Class<?> javaType) {
+        this.javaType = javaType;
+    }
+
+    @Override
+    public Class<?> getJavaType() {
+        return this.javaType;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
@@ -19,12 +19,14 @@ package io.r2dbc.spi;
 import org.reactivestreams.Publisher;
 
 /**
- * A statement that can be executed multiple times in a prepared and optimized way.
+ * A statement that can be executed multiple times in a prepared and optimized way.  Bound parameters can be either scalar values (using type inference for the database parameter type) or
+ * {@link Parameter} objects.
  *
  * @see Result
  * @see Row
  * @see Blob
  * @see Clob
+ * @see Parameter
  */
 public interface Statement {
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Type.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Type.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Type descriptor for column- and parameter types.
+ *
+ * @see R2dbcTypes
+ * @since 0.9
+ */
+public interface Type {
+
+    /**
+     * @return default Java type.
+     */
+    Class<?> getJavaType();
+
+    /**
+     * @return type name.
+     */
+    String getName();
+
+    /**
+     * Marker interface to indicate type inference.  Types are inferred during statement execution by applying type hints.
+     */
+    interface InferredType extends Type {
+
+    }
+}


### PR DESCRIPTION
The spec now clarifies that database types are inferred from scalar values. Type and Parameter allow for explicit database type declaration along with the direction of a parameter (in/out) which is required for stored procedure/server-side functionality invocation. The Type can be obtained from ColumnMetadata.

[#160]